### PR TITLE
[Feat] #26 -  Map 마커 Detail Feed 연결 구현 및 MapMarkerData추가

### DIFF
--- a/app/src/main/java/com/mungkive/application/navigation/AuthNavGraph.kt
+++ b/app/src/main/java/com/mungkive/application/navigation/AuthNavGraph.kt
@@ -7,7 +7,7 @@ import androidx.navigation.compose.composable
 import com.mungkive.application.models.Routes
 import com.mungkive.application.ui.login.LoginView
 import com.mungkive.application.ui.login.WelcomeView
-import com.mungkive.application.ui.profile.ProfileView
+import ProfileView
 
 @Composable
 fun AuthNavGraph(

--- a/app/src/main/java/com/mungkive/application/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/mungkive/application/navigation/MainNavGraph.kt
@@ -14,7 +14,7 @@ import com.mungkive.application.ui.feed.FeedDetailView
 import com.mungkive.application.ui.feed.FeedViewModel
 import com.mungkive.application.ui.feed.FeedWritingView
 import com.mungkive.application.ui.map.MapView
-import com.mungkive.application.ui.profile.ProfileView
+import ProfileView
 import com.mungkive.application.ui.tip.TipListView
 
 @Composable

--- a/app/src/main/java/com/mungkive/application/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/mungkive/application/navigation/MainNavGraph.kt
@@ -15,6 +15,9 @@ import com.mungkive.application.ui.feed.FeedViewModel
 import com.mungkive.application.ui.feed.FeedWritingView
 import com.mungkive.application.ui.map.MapView
 import ProfileView
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import com.mungkive.application.ui.tip.TipListView
 
 @Composable
@@ -27,7 +30,22 @@ fun MainNavGraph(
         startDestination = Routes.Feed.route,
         modifier = modifier
     ) {
-        composable(Routes.Map.route) { MapView() }
+        composable(Routes.Map.route) {
+            val feedViewModel: FeedViewModel = viewModel()
+            val feedList by feedViewModel.feedList.collectAsState()
+
+            // 🔥 ViewModel에서 데이터를 불러오도록 호출
+            LaunchedEffect(Unit) {
+                feedViewModel.fetchFeeds()
+            }
+
+            MapView(
+                feedList = feedList,
+                onFeedSelected = { feedId ->
+                    navController.navigate("${Routes.DetailFeed.route}/$feedId")
+                }
+            )
+        }
         composable(Routes.Feed.route) { backStackEntry ->
             // 1. parentEntry로 NavGraph Scope ViewModel을 만듦
             val parentEntry = remember(backStackEntry) {

--- a/app/src/main/java/com/mungkive/application/ui/map/LoadUrlToOverlayImage.kt
+++ b/app/src/main/java/com/mungkive/application/ui/map/LoadUrlToOverlayImage.kt
@@ -1,0 +1,37 @@
+package com.mungkive.application.ui.map
+
+import android.content.Context
+import coil3.Bitmap
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.request.allowHardware
+import coil3.size.Size
+import coil3.toBitmap
+import com.naver.maps.map.overlay.OverlayImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+// Url -> Bitmap -> OverlayImag(Naver.map 요구 형식) 변환 함수
+suspend fun loadUrlToOverlayImage(context: Context, imageUrl: String): OverlayImage? {
+    return withContext(Dispatchers.IO) {
+        val loader = ImageLoader.Builder(context)
+            .allowHardware(false) // Bitmap 생성 허용
+            .build()
+
+        val request = ImageRequest.Builder(context)
+            .data(imageUrl)
+            .size(Size.ORIGINAL)
+            .build()
+
+        val result = loader.execute(request)
+
+        if (result is SuccessResult) {
+            val image = result.image
+            val bitmap: Bitmap? = image.toBitmap()
+            bitmap?.let { OverlayImage.fromBitmap(it) }
+        } else {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/mungkive/application/ui/map/MapMarkerData.kt
+++ b/app/src/main/java/com/mungkive/application/ui/map/MapMarkerData.kt
@@ -1,0 +1,9 @@
+package com.mungkive.application.ui.map
+
+import com.mungkive.application.ui.feed.FeedData
+import com.naver.maps.geometry.LatLng
+
+data class MapMarkerData(
+    val position: LatLng,
+    val feed: FeedData?
+)

--- a/app/src/main/java/com/mungkive/application/ui/map/MapView.kt
+++ b/app/src/main/java/com/mungkive/application/ui/map/MapView.kt
@@ -36,7 +36,8 @@ fun MapView(modifier: Modifier = Modifier) {
                 state = rememberMarkerState(position = latLng),
                 icon = markerIcon,
                 width = 40.dp,
-                height = 40.dp
+                height = 40.dp,
+
             )
         }
     }

--- a/app/src/main/java/com/mungkive/application/ui/map/MarkerWithUrlIcon.kt
+++ b/app/src/main/java/com/mungkive/application/ui/map/MarkerWithUrlIcon.kt
@@ -1,0 +1,50 @@
+package com.mungkive.application.ui.map
+
+import android.content.Context
+import android.util.Log
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.Marker
+import com.naver.maps.map.compose.rememberMarkerState
+import com.naver.maps.map.overlay.OverlayImage
+
+@OptIn(ExperimentalNaverMapApi::class)
+@Composable
+fun MarkerWithUrlIcon(
+    position: LatLng,
+    url: String,
+    context: Context,
+    onClick: () -> Boolean,
+    modifier: Modifier = Modifier
+) {
+    val overlayImageState = remember { mutableStateOf<OverlayImage?>(null) }
+
+    LaunchedEffect(url) {
+        val result = loadUrlToOverlayImage(context, url)
+        Log.d("OverlayDebug", "🧩 OverlayImage 결과: $result")
+        overlayImageState.value = result
+    }
+
+    if (overlayImageState.value != null) {
+        Log.d("OverlayDebug", "🟢 Marker 생성됨 at $position")
+    }
+
+    overlayImageState.value?.let { overlay ->
+        Marker(
+            state = rememberMarkerState(position = position),
+            icon = overlay,
+            width = 40.dp,
+            height = 40.dp,
+            onClick = {
+                onClick()
+                true
+            }
+        )
+    }
+}


### PR DESCRIPTION
### Issue
closed #26 

### Changed
- MapMarkerData class 생성
- MarkerWithUrlIcon 함수 추가
- MapMarker와 FeedDetailView 연결
- MapMarker의 Icon을 FeedDetail의 사진자료로 변경
- Url to Bitmap to OverlayImage(NaverMap Api 요구 형식) convert 함수 구현

### UI
- 
![MapViewWithUrlImgMarker](https://github.com/user-attachments/assets/3ae9984e-7ad1-4b51-b859-9ba8c722f826)

