### PR TITLE
[Design] #34 - RegisterView 화면 UI 구현

### DIFF
--- a/app/src/main/java/com/mungkive/application/ui/register/RegisterView.kt
+++ b/app/src/main/java/com/mungkive/application/ui/register/RegisterView.kt
@@ -152,7 +152,8 @@ fun RegisterView(modifier: Modifier = Modifier) {
                 modifier = Modifier
                     .fillMaxWidth(0.85f)
                     .height(50.dp),
-                enabled = (passwordText1.isNotEmpty() && passwordText1 == passwordText2)
+                enabled = (idText.isNotEmpty()
+                        && passwordText1.isNotEmpty() && passwordText1 == passwordText2)
             ) {
                 Text(text = "가입하기", fontWeight = FontWeight.Bold, fontSize = 16.sp)
             }

--- a/app/src/main/java/com/mungkive/application/ui/register/RegisterView.kt
+++ b/app/src/main/java/com/mungkive/application/ui/register/RegisterView.kt
@@ -1,0 +1,169 @@
+package com.mungkive.application.ui.register
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mungkive.application.R
+
+@Composable
+fun RegisterView(modifier: Modifier = Modifier) {
+    var idText by remember { mutableStateOf("") }
+    var passwordText1 by remember { mutableStateOf("") }
+    var passwordText2 by remember { mutableStateOf("") }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(vertical = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+
+        // 로고
+        Image(
+            painter = painterResource(R.drawable.dummylogo),
+            contentDescription = null
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        // 환영 문구
+        Text(
+            text = buildAnnotatedString {
+                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                    append("멍카이브")
+                }
+                append("에 오신 것을\n환영합니다!")
+            },
+            fontSize = 28.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentWidth(Alignment.CenterHorizontally)
+        )
+
+        Spacer(modifier = Modifier.height(30.dp))
+
+        // 아이디 입력
+        OutlinedTextField(
+            value = idText,
+            onValueChange = { idText = it },
+            label = { Text("아이디") },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth(0.85f)
+                .height(56.dp),
+            shape = RoundedCornerShape(8.dp)
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // 비밀번호 입력
+        OutlinedTextField(
+            value = passwordText1,
+            onValueChange = { passwordText1 = it },
+            label = { Text("비밀번호") },
+            singleLine = true,
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            modifier = Modifier
+                .fillMaxWidth(0.85f)
+                .height(56.dp),
+            shape = RoundedCornerShape(8.dp)
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // 비밀번호 재입력
+        OutlinedTextField(
+            value = passwordText2,
+            onValueChange = { passwordText2 = it },
+            label = { Text("비밀번호 재입력") },
+            singleLine = true,
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            modifier = Modifier
+                .fillMaxWidth(0.85f)
+                .height(56.dp),
+            shape = RoundedCornerShape(8.dp)
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = if (passwordText1.isNotEmpty() && passwordText1 != passwordText2) {
+                "비밀번호가 일치하지 않습니다"
+            } else {
+                ""
+            },
+            fontSize = 12.sp,
+            textAlign = TextAlign.Left,
+            modifier = Modifier.fillMaxWidth(0.85f),
+            color = Color.Red
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        // 버튼들
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Button(
+                onClick = {
+                    // TODO: Register Process, Transition to Profile Registration
+                },
+                shape = RoundedCornerShape(50.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF3378F6),
+                    contentColor = Color.White
+                ),
+                modifier = Modifier
+                    .fillMaxWidth(0.85f)
+                    .height(50.dp),
+                enabled = (passwordText1.isNotEmpty() && passwordText1 == passwordText2)
+            ) {
+                Text(text = "가입하기", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+    }
+}
+
+@Preview
+@Composable
+private fun RegisterViewPreview() {
+    RegisterView()
+}


### PR DESCRIPTION
### Issue
closed #34 

### Changed
- RegisterView 화면 UI 구현

### UI
| RegisterView | 비밀번호 불일치 시 | 비밀번호 일치 시 |
|--|--|--|
| <img width="260px" alt="image" src="https://github.com/user-attachments/assets/a39c03e0-990a-4340-aa04-6a916aef4050" /> | <img width="260px" alt="image" src="https://github.com/user-attachments/assets/da5d7df7-e6c0-4ba7-993f-750206835ac5" /> | <img width="260px" alt="image" src="https://github.com/user-attachments/assets/ae7bc5e9-f02f-4557-9016-094bfa304cc4" /> |
- 비밀번호 불일치 시 "가입하기" 버튼 비활성화 및 불일치 메시지 표시
- 모든 필드 작성 및 비밀번호 일치 시 "가입하기 버튼 활성화

### References
X
