### PR TITLE
[Fix] #59 - TextField 글자 잘림 문제 수정

### DIFF
--- a/app/src/main/java/com/mungkive/application/ui/login/LoginView.kt
+++ b/app/src/main/java/com/mungkive/application/ui/login/LoginView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -90,7 +91,7 @@ fun LoginView(
             singleLine = true,
             modifier = Modifier
                 .fillMaxWidth(0.85f)
-                .height(56.dp),
+                .defaultMinSize(minHeight = 56.dp),
             shape = RoundedCornerShape(8.dp)
         )
 
@@ -106,7 +107,7 @@ fun LoginView(
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
             modifier = Modifier
                 .fillMaxWidth(0.85f)
-                .height(56.dp),
+                .defaultMinSize(minHeight = 56.dp),
             shape = RoundedCornerShape(8.dp)
         )
 

--- a/app/src/main/java/com/mungkive/application/ui/login/LoginView.kt
+++ b/app/src/main/java/com/mungkive/application/ui/login/LoginView.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,6 +45,10 @@ fun LoginView(
     onLoginSuccess: () -> Unit,
     onRegisterClick: () -> Unit
 ) {
+    LaunchedEffect(Unit) {
+        viewModel::clearIdAndPw
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()

--- a/app/src/main/java/com/mungkive/application/ui/profile/AddProfileView.kt
+++ b/app/src/main/java/com/mungkive/application/ui/profile/AddProfileView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -83,7 +84,7 @@ fun AddProfileView(
             singleLine = true,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp),
+                .defaultMinSize(minHeight = 56.dp),
             shape = RoundedCornerShape(8.dp)
         )
 
@@ -97,7 +98,7 @@ fun AddProfileView(
             singleLine = true,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp),
+                .defaultMinSize(minHeight = 56.dp),
             shape = RoundedCornerShape(8.dp)
         )
 
@@ -112,7 +113,7 @@ fun AddProfileView(
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp),
+                .defaultMinSize(minHeight = 56.dp),
             shape = RoundedCornerShape(8.dp)
         )
 

--- a/app/src/main/java/com/mungkive/application/ui/profile/ProfileView.kt
+++ b/app/src/main/java/com/mungkive/application/ui/profile/ProfileView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -120,7 +121,7 @@ fun ProfileView(
             singleLine = true,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp),
+                .defaultMinSize(minHeight = 56.dp),
             shape = RoundedCornerShape(8.dp),
             enabled = (isEditing)
         )
@@ -135,7 +136,7 @@ fun ProfileView(
             singleLine = true,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp),
+                .defaultMinSize(minHeight = 56.dp),
             shape = RoundedCornerShape(8.dp),
             enabled = (isEditing)
         )
@@ -151,7 +152,7 @@ fun ProfileView(
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp),
+                .defaultMinSize(minHeight = 56.dp),
             shape = RoundedCornerShape(8.dp),
             enabled = (isEditing)
         )

--- a/app/src/main/java/com/mungkive/application/ui/register/RegisterView.kt
+++ b/app/src/main/java/com/mungkive/application/ui/register/RegisterView.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,6 +45,10 @@ fun RegisterView(
     viewModel: ApiTestViewModel,
     onRegisterSuccess: () -> Unit
 ) {
+    LaunchedEffect(Unit) {
+        viewModel::clearIdAndPw
+    }
+
     var passwordText by remember { mutableStateOf("") }
     val context = LocalContext.current
 

--- a/app/src/main/java/com/mungkive/application/ui/register/RegisterView.kt
+++ b/app/src/main/java/com/mungkive/application/ui/register/RegisterView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -93,7 +94,7 @@ fun RegisterView(
             singleLine = true,
             modifier = Modifier
                 .fillMaxWidth(0.85f)
-                .height(56.dp),
+                .defaultMinSize(minHeight = 56.dp),
             shape = RoundedCornerShape(8.dp)
         )
 
@@ -109,7 +110,7 @@ fun RegisterView(
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
             modifier = Modifier
                 .fillMaxWidth(0.85f)
-                .height(56.dp),
+                .defaultMinSize(minHeight = 56.dp),
             shape = RoundedCornerShape(8.dp)
         )
 
@@ -125,7 +126,7 @@ fun RegisterView(
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
             modifier = Modifier
                 .fillMaxWidth(0.85f)
-                .height(56.dp),
+                .defaultMinSize(minHeight = 56.dp),
             shape = RoundedCornerShape(8.dp)
         )
 

--- a/app/src/main/java/com/mungkive/application/viewmodels/ApiTestViewModel.kt
+++ b/app/src/main/java/com/mungkive/application/viewmodels/ApiTestViewModel.kt
@@ -29,6 +29,11 @@ class ApiTestViewModel(
     fun onIdChange(newId: String) = run { id = newId }
     fun onPwChange(newPw: String) = run { pw = newPw }
 
+    fun clearIdAndPw() {
+        id = ""
+        pw = ""
+    }
+
     // Profile
     var name by mutableStateOf("")
         private set


### PR DESCRIPTION
### Issue
closed #59 

### Changed
- OutlinedTextField 텍스트 잘림 문제 수정 (`height` → `defaultMinHeight` 지정)

| Register (Fixed) |
|--|
| <img width="300px" alt="" src="https://github.com/user-attachments/assets/76627c90-0e08-4518-97a0-f46197340f90" /> |

